### PR TITLE
Return typed error when no candidate pairs

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -796,7 +796,7 @@ func (a *Agent) getBestPair() (*candidatePair, error) {
 	out := <-res
 
 	if out == nil {
-		return nil, errors.New("no Valid Candidate Pairs Available")
+		return nil, ErrNoCandidatePairs
 	}
 
 	return out, nil

--- a/errors.go
+++ b/errors.go
@@ -26,4 +26,7 @@ var (
 
 	// ErrClosed indicates the agent is closed
 	ErrClosed = errors.New("the agent is closed")
+
+	// ErrNoCandidatePairs indicates agent does not have a valid candidate pair
+	ErrNoCandidatePairs = errors.New("no candidate pairs available")
 )


### PR DESCRIPTION
Returning a typed error allows us to handle it gracefully in pions/webrtc
