### PR TITLE
ice-tcp-passive

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -228,13 +228,36 @@ func (a *Agent) listenUDP(network string, laddr *net.UDPAddr) (*net.UDPConn, err
 	return nil, ErrPort
 }
 
+// networksSupported - intersect needed and supported network types
+func (a *Agent) networksSupported(networkTypes []NetworkType) []string {
+	m := map[string]bool{}
+	for _, network := range supportedNetworks {
+		m[network] = false
+	}
+	for _, network3 := range networkTypes {
+		net := network3.NetworkShort()
+		if _, ok := m[net]; ok {
+			m[net] = true
+		}
+	}
+	netIntersect := []string{}
+	for k, v := range m {
+		if v {
+			netIntersect = append(netIntersect, k)
+		}
+	}
+	return netIntersect
+}
+
 func (a *Agent) gatherCandidatesLocal(networkTypes []NetworkType) {
 	var conn net.PacketConn
 	var err error
+	networks := a.networksSupported(networkTypes)
 	localIPs := localInterfaces(networkTypes)
 	port := 0
 	for _, ip := range localIPs {
-		for _, network := range supportedNetworks {
+		for _, network := range networks {
+
 			switch network {
 			case "udp":
 				conn, err = a.listenUDP(network, &net.UDPAddr{IP: ip, Port: 0})

--- a/agent.go
+++ b/agent.go
@@ -114,7 +114,7 @@ type AgentConfig struct {
 	PortMax uint16
 
 	// TCPPort are optional,  Leave them 0 for the default TCP port allocation strategy.
-	// usefull for "only http" firewall
+	// useful for "only http" firewall
 	TCPPort uint16
 
 	// ConnectionTimeout defaults to 30 seconds when this property is nil.
@@ -259,15 +259,15 @@ func (a *Agent) gatherCandidatesLocal(networkTypes []NetworkType) {
 		for _, network := range networks {
 
 			switch network {
-			case "udp":
+			case udp:
 				conn, err = a.listenUDP(network, &net.UDPAddr{IP: ip, Port: 0})
 				if err != nil {
 					a.log.Warnf("could not listen %s %s\n", network, ip)
 					continue
 				}
 				port = conn.LocalAddr().(*net.UDPAddr).Port
-			case "tcp":
-				if a.isControlling == false {
+			case tcp:
+				if !a.isControlling {
 					conn, err = a.listenTCP(network, &net.TCPAddr{IP: ip, Port: 0})
 					if err != nil {
 						a.log.Warnf("could not listen %s %s\n", network, ip)

--- a/networktype.go
+++ b/networktype.go
@@ -13,14 +13,14 @@ const (
 
 var supportedNetworks = []string{
 	udp,
-	// tcp, // Not supported yet
+	tcp, // only tcp-passive (server side) supported yet
 }
 
 var supportedNetworkTypes = []NetworkType{
 	NetworkTypeUDP4,
 	NetworkTypeUDP6,
-	// NetworkTypeTCP4, // Not supported yet
-	// NetworkTypeTCP6, // Not supported yet
+	NetworkTypeTCP4, // Not supported yet
+	NetworkTypeTCP6, // Not supported yet
 }
 
 // NetworkType represents the type of network

--- a/networktype.go
+++ b/networktype.go
@@ -19,8 +19,8 @@ var supportedNetworks = []string{
 var supportedNetworkTypes = []NetworkType{
 	NetworkTypeUDP4,
 	NetworkTypeUDP6,
-	NetworkTypeTCP4, // Not supported yet
-	NetworkTypeTCP6, // Not supported yet
+	NetworkTypeTCP4,
+	NetworkTypeTCP6,
 }
 
 // NetworkType represents the type of network

--- a/tcp-mux.go
+++ b/tcp-mux.go
@@ -1,0 +1,223 @@
+package ice
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/pions/logging"
+	"github.com/pions/stun"
+)
+
+// ConnReadPacket read 1 packet from stream
+// read packet  bytes https://tools.ietf.org/html/rfc4571#section-2
+// 2-byte lenght header prepends each packet:
+//     0                   1                   2                   3
+//     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//     ---------------------------------------------------------------
+//    |             LENGTH            |  RTP or RTCP packet ...       |
+//     ---------------------------------------------------------------
+func ConnReadPacket(c net.Conn, b []byte) (int, error) {
+	tmplen := []byte{0, 0}
+	n1, err := c.Read(tmplen)
+	if err != nil {
+		return 0, err
+	}
+
+	if n1 != len(tmplen) {
+		n1, err = c.Read(tmplen[1:])
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	pktLen := int(binary.BigEndian.Uint16(tmplen))
+	if pktLen > cap(b) {
+		return pktLen, io.ErrShortBuffer
+	}
+	readed := 0
+	for readed < pktLen {
+		n, err := c.Read(b[readed:pktLen])
+		if err != nil {
+			log.Print(err)
+			break
+		}
+		readed += n
+		b = b[0:readed]
+	}
+	return readed, err
+}
+
+// one port for all connections.
+// first of all - main key is a binding address:port (root listener)
+// Second level key - local session ufrag
+//
+
+// muxerTCP
+type muxerTCP struct {
+	packetConns map[string]*packetTCP
+	listener    net.Listener
+	sync.Mutex
+	log *logging.LeveledLogger
+}
+
+// listeners are global!
+var portsMap = make(map[string]*muxerTCP)
+var portsMapLock = &sync.Mutex{}
+
+//getMuxerTCP binds listener to muxer lufrag:rufrag
+func (a *Agent) getMuxerTCP(network string, laddr *net.TCPAddr) (*muxerTCP, error) {
+	// checks muxing listener already armed
+	laddr.Port = int(a.tcpport)
+	if laddr.Port != 0 {
+		if mux, ok := portsMap[laddr.String()]; ok {
+			return mux, nil
+		}
+	}
+	listener, err := net.ListenTCP(network, laddr)
+	if err != nil {
+		return nil, ErrPort
+	}
+	bindToAddr := listener.Addr().String()
+	mux := &muxerTCP{
+		listener:    listener,
+		packetConns: make(map[string]*packetTCP),
+		log:         logging.NewScopedLogger("ice"),
+	}
+	portsMap[bindToAddr] = mux
+	go mux.listen()
+	return mux, nil
+}
+
+// FIXME!!!!
+func (mux *muxerTCP) freePacketConn(ufrag string) {
+	// delete port ref
+	portsMapLock.Lock()
+	mux.Lock()
+	delete(mux.packetConns, ufrag)
+	// if listener []packetConns empty - close it
+	if len(mux.packetConns) == 0 {
+		addr := mux.listener.Addr().String()
+		mux.listener.Close()
+		delete(portsMap, addr)
+	}
+	portsMapLock.Unlock()
+}
+
+//listen - listen connection(s) on port
+func (mux *muxerTCP) listen() {
+	for {
+		c, err := mux.listener.Accept()
+		if err != nil {
+			mux.log.Errorf("listener on %v: %v", mux.listener.Addr().String(), err)
+			return
+		}
+		go mux.bridgeWorker(c)
+	}
+}
+
+//bridgeWorker conn->packet
+func (mux *muxerTCP) bridgeWorker(c net.Conn) {
+	defer c.Close()
+	mux.log.Warnf("bridge packetConn for conn %v", c.RemoteAddr().String())
+	b := make([]byte, receiveMTU)
+	// read & parce first packet from Conn
+	n, err := ConnReadPacket(c, b)
+	if err != nil {
+		mux.log.Warnf("Error @%v : %v", c.RemoteAddr().String(), err)
+		return
+	}
+	b = b[0:n]
+	tpc, ufrag := mux.findPacketConn(b)
+	if tpc == nil {
+		mux.log.Warnf("no packetConn for conn %v ufrag:\"%v\"", c.RemoteAddr().String(), ufrag)
+		return
+	}
+	if tpc.linked {
+		mux.log.Warnf("already bind %v ufrag:\"%v\"", c.RemoteAddr().String(), ufrag)
+		return
+	}
+	tpc.linked = true
+	srcAddr := c.RemoteAddr()
+	tpc.downstream <- &incomingPacket{buffer: b, srcAddr: &srcAddr}
+	// tcp->packet
+	go func() {
+		for {
+			b := make([]byte, receiveMTU)
+			if n, err = ConnReadPacket(c, b); err == nil {
+				b = b[0:n]
+				select {
+				case tpc.downstream <- &incomingPacket{buffer: b, srcAddr: &srcAddr}:
+				default:
+				}
+				continue
+			}
+			if err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
+				mux.log.Warnf("Error: %v :\"%v\"", c.RemoteAddr().String(), err.Error())
+			}
+			break
+		}
+	}()
+	// packet->tcp
+	toConn := &[]byte{}
+	for {
+		if toConn, _ = <-tpc.upstream; toConn == nil { // slave closed
+			mux.freePacketConn(ufrag) // free muxer ufrag ref
+			break
+		}
+		if _, err := c.Write(*toConn); err != nil {
+			mux.log.Warnf("Error: %v :\"%v\"", c.RemoteAddr().String(), err.Error())
+		}
+	}
+	tpc.linked = false
+}
+
+//findPacketConn returns the corresponding port by the value of the attribute stun.AttrUsername
+func (mux *muxerTCP) findPacketConn(b []byte) (socket *packetTCP, username string) {
+	// if username = usernameHelper(b); username == "" {
+	// 	return nil, ""
+	// }
+	m, _ := stun.NewMessage(b)
+	if m == nil || m.Method != stun.MethodBinding { // not a stun
+		return nil, ""
+	}
+	attr, _ := m.GetOneAttribute(stun.AttrIceControlled) // only TCP passive
+	if attr == nil {
+		return nil, ""
+	}
+
+	attr, _ = m.GetOneAttribute(stun.AttrUsername)
+	if attr == nil {
+		return nil, ""
+	}
+	username = string(attr.Value)
+
+	if socket = mux.packetConns[strings.Split(username, ":")[0]]; socket != nil {
+		mux.log.Infof("got socket for %v", username)
+	}
+	return socket, username
+}
+
+// listenTCP works similar to listenUDP
+func (a *Agent) listenTCP(network string, laddr *net.TCPAddr) (*packetTCP, error) {
+	portsMapLock.Lock()
+	defer portsMapLock.Unlock()
+	mux, err := a.getMuxerTCP(network, laddr)
+	if err != nil {
+		return nil, err
+	}
+
+	mux.Lock()
+	defer mux.Unlock()
+	if _, ok := mux.packetConns[a.localUfrag]; ok {
+		return nil, fmt.Errorf("Duplicate ufrag %v", a.localUfrag)
+	}
+
+	conn := newPacketTCP(mux.listener.Addr())
+	mux.packetConns[a.localUfrag] = conn
+	return conn, nil
+}

--- a/tcp-packetconn.go
+++ b/tcp-packetconn.go
@@ -1,0 +1,113 @@
+package ice
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+)
+
+const queueLen = 15
+
+//ConnValidator interface, that used for check accepted connection validity
+type ConnValidator interface {
+	IsValid(interface{}) bool
+}
+
+type incomingPacket struct {
+	srcAddr *net.Addr
+	buffer  []byte
+}
+
+//packetTCP paket over tcp conn
+type packetTCP struct {
+	upstream   chan *[]byte
+	downstream chan *incomingPacket
+	linked     bool
+	validator  ConnValidator
+	sync.Mutex
+	uniq  int
+	local net.Addr
+}
+
+//newPacketTCP new connection
+func newPacketTCP(local net.Addr) *packetTCP {
+	return &packetTCP{
+		upstream:   make(chan *[]byte, queueLen),
+		downstream: make(chan *incomingPacket, queueLen),
+		linked:     false,
+		uniq:       rand.Int(),
+		local:      local,
+	}
+}
+
+// ReadFrom reads from...
+func (t *packetTCP) ReadFrom(b []byte) (n int, src net.Addr, err error) {
+	pkt, ok := <-t.downstream
+	if ok {
+		err = nil
+		n = len(pkt.buffer)
+		copy(b, pkt.buffer)
+		return n, *pkt.srcAddr, err
+	}
+	err = io.ErrClosedPipe
+	return n, nil, err
+}
+
+// WriteTo write bytes. Chan is for not opened tcp conn
+func (t *packetTCP) WriteTo(b []byte, dst net.Addr) (n int, err error) {
+	if dst.(*net.UDPAddr).Port == 9 {
+		return
+	}
+	bufferCopy := make([]byte, len(b)+2)
+	binary.BigEndian.PutUint16(bufferCopy, uint16(len(b)))
+	copy(bufferCopy[2:], b)
+	select {
+	case t.upstream <- &bufferCopy:
+	default:
+		fmt.Println("out queue full")
+	}
+	return len(b), err
+}
+
+// Close ...
+func (t *packetTCP) Close() error {
+	if t.linked {
+		t.upstream <- nil
+	}
+	t.linked = false
+	return nil
+}
+
+//LocalAddr returns address listens to
+func (t *packetTCP) LocalAddr() net.Addr {
+	return t.local
+}
+
+//SetValidator return parent value
+func (t *packetTCP) SetValidator(i ConnValidator) {
+	t.validator = i
+}
+
+//GetParent returns address listens to
+func (t *packetTCP) GetParent() ConnValidator {
+	return t.validator
+}
+
+//SetDeadline ...
+func (t *packetTCP) SetDeadline(tm time.Time) error {
+	return nil
+}
+
+// SetReadDeadline ...
+func (t *packetTCP) SetReadDeadline(tm time.Time) error {
+	return nil
+}
+
+// SetWriteDeadline ...
+func (t *packetTCP) SetWriteDeadline(tm time.Time) error {
+	return nil
+}

--- a/tcp-packetconn.go
+++ b/tcp-packetconn.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"sync"
 	"time"
@@ -29,7 +28,6 @@ type packetTCP struct {
 	linked     bool
 	validator  ConnValidator
 	sync.Mutex
-	uniq  int
 	local net.Addr
 }
 
@@ -39,7 +37,6 @@ func newPacketTCP(local net.Addr) *packetTCP {
 		upstream:   make(chan *[]byte, queueLen),
 		downstream: make(chan *incomingPacket, queueLen),
 		linked:     false,
-		uniq:       rand.Int(),
 		local:      local,
 	}
 }


### PR DESCRIPTION
#### Description
Adding ice-tcp-passive candidate type
works in two modes: fixed & random port (based by AgentConfig.TCPPort)
### Warning
Due to the structural limitations of the ice.Agent, it is not possible to use this option in answerer mode


